### PR TITLE
Feature/carousel

### DIFF
--- a/app/Http/Controllers/BannerController.php
+++ b/app/Http/Controllers/BannerController.php
@@ -57,6 +57,45 @@ class BannerController extends Controller
     }
 
     /**
+     * Get the current active featured banners
+     * 
+     * @OA\Get(
+     *     path="/api/featured-banners",
+     *     summary="Get active featured banners",
+     *     description="Returns the currently active featured banners",
+     *     operationId="getFeaturedBanners",
+     *     tags={"Banners"},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful operation",
+     *         @OA\JsonContent(
+     *             type="array",
+     *             @OA\Items(ref="#/components/schemas/Banner")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="No featured banners found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="No featured banners found")
+     *         )
+     *     )
+     * )
+     */
+    public function getFeatured()
+    {
+        $featuredBanners = Banner::where('is_active', true)
+                                ->where('type', 'featured')
+                                ->get();
+        
+        if ($featuredBanners->isEmpty()) {
+            return response()->json(['message' => 'No featured banners found'], 404);
+        }
+        
+        return response()->json($featuredBanners);
+    }
+
+    /**
      * Store a new banner and replace any existing one of the same type
      * 
      * @OA\Post(
@@ -80,7 +119,7 @@ class BannerController extends Controller
      *                 @OA\Property(
      *                     property="type",
      *                     type="string",
-     *                     enum={"mobile", "desktop"},
+     *                     enum={"mobile", "desktop", "featured"},
      *                     description="Banner type",
      *                     example="desktop"
      *                 ),
@@ -134,7 +173,7 @@ class BannerController extends Controller
     {
         $validator = Validator::make($request->all(), [
             'image' => 'required|image|max:2048', // Max 2MB
-            'type' => 'required|in:mobile,desktop',
+            'type' => 'required|in:mobile,desktop,featured',
             'title' => 'nullable|string|max:255',
             'subtitle' => 'nullable|string|max:255',
             'link' => 'nullable|url|max:255',
@@ -198,7 +237,7 @@ class BannerController extends Controller
      *         required=true,
      *         @OA\Schema(
      *             type="string",
-     *             enum={"mobile", "desktop"}
+     *             enum={"mobile", "desktop", "featured"}
      *         )
      *     ),
      *     @OA\Response(
@@ -234,7 +273,7 @@ class BannerController extends Controller
      */
     public function destroy($type)
     {
-        if (!in_array($type, ['mobile', 'desktop'])) {
+        if (!in_array($type, ['mobile', 'desktop', 'featured'])) {
             return response()->json(['message' => 'Invalid banner type'], 400);
         }
 

--- a/app/Http/Controllers/BannerController.php
+++ b/app/Http/Controllers/BannerController.php
@@ -101,7 +101,7 @@ class BannerController extends Controller
      * @OA\Post(
      *     path="/api/admin/banner",
      *     summary="Upload a new banner",
-     *     description="Uploads a new banner and replaces any existing one of the same type",
+     *     description="Uploads a new banner. For mobile/desktop types, replaces existing banner. For featured type, allows up to 3 banners.",
      *     operationId="storeBanner",
      *     tags={"Banners"},
      *     security={{"sanctum":{}}},
@@ -154,9 +154,10 @@ class BannerController extends Controller
      *     ),
      *     @OA\Response(
      *         response=422,
-     *         description="Validation error",
+     *         description="Validation error or featured banner limit exceeded",
      *         @OA\JsonContent(
-     *             @OA\Property(property="errors", type="object")
+     *             @OA\Property(property="errors", type="object"),
+     *             @OA\Property(property="message", type="string", example="Maximum of 3 featured banners allowed. Please delete an existing one first.")
      *         )
      *     ),
      *     @OA\Response(
@@ -176,36 +177,60 @@ class BannerController extends Controller
             'type' => 'required|in:mobile,desktop,featured',
             'title' => 'nullable|string|max:255',
             'subtitle' => 'nullable|string|max:255',
-            'link' => 'nullable|url|max:255',
+            'link' => 'nullable|string|max:255', // Changed from url to string for more flexibility
         ]);
 
         if ($validator->fails()) {
-            return response()->json(['errors' => $validator->errors()], 422);
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+                'received_data' => [
+                    'type' => $request->get('type'),
+                    'title' => $request->get('title'),
+                    'subtitle' => $request->get('subtitle'),
+                    'link' => $request->get('link'),
+                    'has_image' => $request->hasFile('image'),
+                ]
+            ], 422);
         }
 
         // Handle the file upload
         $imagePath = $request->file('image')->store('banners', 'public');
         
-        // Deactivate existing banners of the same type
-        Banner::where('is_active', true)
-              ->where('type', $request->type)
-              ->update(['is_active' => false]);
-        
-        // Delete old banner images of the same type to save space
-        $oldBanners = Banner::where('is_active', false)
-                           ->where('type', $request->type)
-                           ->get();
-        foreach ($oldBanners as $oldBanner) {
-            // Remove the file
-            if (Storage::disk('public')->exists($oldBanner->image_path)) {
-                Storage::disk('public')->delete($oldBanner->image_path);
+        // Handle different logic for featured vs other banner types
+        if ($request->type === 'featured') {
+            // For featured banners, check if we already have 3
+            $featuredCount = Banner::where('is_active', true)
+                                  ->where('type', 'featured')
+                                  ->count();
+            
+            if ($featuredCount >= 3) {
+                return response()->json([
+                    'message' => 'Maximum of 3 featured banners allowed. Please delete an existing one first.'
+                ], 422);
             }
+        } else {
+            // For mobile/desktop banners, replace existing ones (original behavior)
+            Banner::where('is_active', true)
+                  ->where('type', $request->type)
+                  ->update(['is_active' => false]);
+            
+            // Delete old banner images of the same type to save space
+            $oldBanners = Banner::where('is_active', false)
+                               ->where('type', $request->type)
+                               ->get();
+            foreach ($oldBanners as $oldBanner) {
+                // Remove the file
+                if (Storage::disk('public')->exists($oldBanner->image_path)) {
+                    Storage::disk('public')->delete($oldBanner->image_path);
+                }
+            }
+            
+            // Delete old banner records of the same type
+            Banner::where('is_active', false)
+                  ->where('type', $request->type)
+                  ->delete();
         }
-        
-        // Delete old banner records of the same type
-        Banner::where('is_active', false)
-              ->where('type', $request->type)
-              ->delete();
 
         // Create the new banner
         $banner = Banner::create([
@@ -293,5 +318,69 @@ class BannerController extends Controller
         $banner->delete();
         
         return response()->json(['message' => 'Banner deleted successfully']);
+    }
+
+    /**
+     * Delete featured banner by ID
+     * 
+     * @OA\Delete(
+     *     path="/api/admin/banner/featured/{id}",
+     *     summary="Delete featured banner by ID",
+     *     description="Deletes a specific featured banner by its ID",
+     *     operationId="destroyFeaturedBanner",
+     *     tags={"Banners"},
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Featured banner ID",
+     *         required=true,
+     *         @OA\Schema(
+     *             type="integer"
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Featured banner deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Featured banner deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Featured banner not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Featured banner not found")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Unauthorized"
+     *     )
+     * )
+     */
+    public function destroyFeatured($id)
+    {
+        $banner = Banner::where('id', $id)
+                       ->where('type', 'featured')
+                       ->where('is_active', true)
+                       ->first();
+        
+        if (!$banner) {
+            return response()->json(['message' => 'Featured banner not found'], 404);
+        }
+        
+        // Delete the image file
+        if (Storage::disk('public')->exists($banner->image_path)) {
+            Storage::disk('public')->delete($banner->image_path);
+        }
+        
+        $banner->delete();
+        
+        return response()->json(['message' => 'Featured banner deleted successfully']);
     }
 }

--- a/database/migrations/2025_06_12_034138_add_type_to_banners_table.php
+++ b/database/migrations/2025_06_12_034138_add_type_to_banners_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
    public function up()
 {
     Schema::table('banners', function (Blueprint $table) {
-        $table->enum('type', ['mobile', 'desktop'])->after('image_path');
+        $table->enum('type', ['mobile', 'desktop', 'featured'])->after('image_path');
     });
 }
 

--- a/database/migrations/2025_09_16_095119_add_featured_type_to_banners_table.php
+++ b/database/migrations/2025_09_16_095119_add_featured_type_to_banners_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('banners', function (Blueprint $table) {
+            // Modify the enum column to include 'featured'
+            DB::statement("ALTER TABLE banners MODIFY COLUMN type ENUM('mobile', 'desktop', 'featured') NOT NULL");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('banners', function (Blueprint $table) {
+            // Revert back to original enum values
+            DB::statement("ALTER TABLE banners MODIFY COLUMN type ENUM('mobile', 'desktop') NOT NULL");
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -73,6 +73,7 @@ Route::post('/orders/cod', [OrderController::class, 'createCodOrder']);
 Route::get('/orders/{id}', [OrderController::class, 'getOrder']);
 
 Route::get('/banner', [BannerController::class, 'show']);
+Route::get('/featured-banners', [BannerController::class, 'getFeatured']);
 
 Route::get('/cod-limit', [CodLimitController::class, 'show']);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -125,7 +125,8 @@ Route::prefix('admin')->group(function () {
             Route::put('/orders/{id}/payment-status', [OrderController::class, 'updatePaymentStatus']);
 
             Route::post('/banner', [BannerController::class, 'store']);
-            Route::delete('/banner', [BannerController::class, 'destroy']);
+            Route::delete('/banner/{type}', [BannerController::class, 'destroy']);
+            Route::delete('/banner/featured/{id}', [BannerController::class, 'destroyFeatured']);
 
             Route::post('/mobile-numbers', [MobileNumberController::class, 'store']);
             Route::put('/mobile-numbers/{mobile_number}', [MobileNumberController::class, 'update']);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -303,6 +303,47 @@
                 }
             }
         },
+        "/api/featured-banners": {
+            "get": {
+                "tags": [
+                    "Banners"
+                ],
+                "summary": "Get active featured banners",
+                "description": "Returns the currently active featured banners",
+                "operationId": "getFeaturedBanners",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Banner"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No featured banners found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "No featured banners found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/admin/banner": {
             "post": {
                 "tags": [
@@ -327,7 +368,8 @@
                                         "type": "string",
                                         "enum": [
                                             "mobile",
-                                            "desktop"
+                                            "desktop",
+                                            "featured"
                                         ],
                                         "example": "desktop"
                                     },
@@ -419,7 +461,8 @@
                             "type": "string",
                             "enum": [
                                 "mobile",
-                                "desktop"
+                                "desktop",
+                                "featured"
                             ]
                         }
                     }

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -350,7 +350,7 @@
                     "Banners"
                 ],
                 "summary": "Upload a new banner",
-                "description": "Uploads a new banner and replaces any existing one of the same type",
+                "description": "Uploads a new banner. For mobile/desktop types, replaces existing banner. For featured type, allows up to 3 banners.",
                 "operationId": "storeBanner",
                 "requestBody": {
                     "required": true,
@@ -415,13 +415,17 @@
                         }
                     },
                     "422": {
-                        "description": "Validation error",
+                        "description": "Validation error or featured banner limit exceeded",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "properties": {
                                         "errors": {
                                             "type": "object"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Maximum of 3 featured banners allowed. Please delete an existing one first."
                                         }
                                     },
                                     "type": "object"
@@ -509,6 +513,72 @@
                                         "message": {
                                             "type": "string",
                                             "example": "No active banner found for this type"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/admin/banner/featured/{id}": {
+            "delete": {
+                "tags": [
+                    "Banners"
+                ],
+                "summary": "Delete featured banner by ID",
+                "description": "Deletes a specific featured banner by its ID",
+                "operationId": "destroyFeaturedBanner",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Featured banner ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Featured banner deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Featured banner deleted successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Featured banner not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Featured banner not found"
                                         }
                                     },
                                     "type": "object"


### PR DESCRIPTION
This pull request introduces support for "featured" banners to the system, allowing up to three active featured banners at a time. It adds new API endpoints for retrieving and deleting featured banners, updates the validation and storage logic to handle the new type, and ensures all documentation and schema definitions reflect these changes.

**Featured Banner Functionality**

* Added support for a new `featured` banner type, including logic to allow up to three active featured banners and to prevent exceeding this limit when creating new ones. [[1]](diffhunk://#diff-6185104b4bcedf63e1bc4636bfaac0e80f5bd793ed1c058a5db802e1734d23c9L137-R213) [[2]](diffhunk://#diff-6185104b4bcedf63e1bc4636bfaac0e80f5bd793ed1c058a5db802e1734d23c9L118-R160)
* Implemented a new API endpoint `GET /api/featured-banners` to retrieve active featured banners, with appropriate OpenAPI documentation and error handling. [[1]](diffhunk://#diff-6185104b4bcedf63e1bc4636bfaac0e80f5bd793ed1c058a5db802e1734d23c9R59-R104) [[2]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR76) [[3]](diffhunk://#diff-6528bc20d3aa7a292ad6698508df2ec69b2941bd0aa39c40a791a27fd6f1c162R306-R353)

**Banner Deletion Improvements**

* Added a new API endpoint `DELETE /api/admin/banner/featured/{id}` to delete a specific featured banner by ID, including image file cleanup and OpenAPI documentation. [[1]](diffhunk://#diff-6185104b4bcedf63e1bc4636bfaac0e80f5bd793ed1c058a5db802e1734d23c9R322-R385) [[2]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dL127-R129) [[3]](diffhunk://#diff-6528bc20d3aa7a292ad6698508df2ec69b2941bd0aa39c40a791a27fd6f1c162R537-R602)
* Updated the existing `destroy` method and route to support deletion of banners by type, including the new `featured` type. [[1]](diffhunk://#diff-6185104b4bcedf63e1bc4636bfaac0e80f5bd793ed1c058a5db802e1734d23c9L237-R301) [[2]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dL127-R129)

**Database and Validation Updates**

* Updated the `banners` table schema to include the new `featured` type in the `type` enum, with new and modified migrations for compatibility. [[1]](diffhunk://#diff-113a3264bf800a60e909b7d10f8b54cce74ac463e6082ef2448d6ee88229c1eaL12-R12) [[2]](diffhunk://#diff-c2b94b7a1473bcbfbe53d9c9e89eac88bedd693d39bfe6729b7d07a1bd3990aeR1-R31)
* Adjusted validation logic for banner creation: allowed `featured` as a valid type, changed `link` validation from URL to string for flexibility, and improved error responses for validation failures and featured banner limit enforcement. [[1]](diffhunk://#diff-6185104b4bcedf63e1bc4636bfaac0e80f5bd793ed1c058a5db802e1734d23c9L137-R213) [[2]](diffhunk://#diff-6185104b4bcedf63e1bc4636bfaac0e80f5bd793ed1c058a5db802e1734d23c9L118-R160)

**API Documentation Updates**

* Updated OpenAPI documentation and `api-docs.json` to reflect the new endpoints, banner type, validation error messages, and featured banner behaviors. [[1]](diffhunk://#diff-6528bc20d3aa7a292ad6698508df2ec69b2941bd0aa39c40a791a27fd6f1c162R306-R353) [[2]](diffhunk://#diff-6528bc20d3aa7a292ad6698508df2ec69b2941bd0aa39c40a791a27fd6f1c162L330-R372) [[3]](diffhunk://#diff-6528bc20d3aa7a292ad6698508df2ec69b2941bd0aa39c40a791a27fd6f1c162L376-R428) [[4]](diffhunk://#diff-6528bc20d3aa7a292ad6698508df2ec69b2941bd0aa39c40a791a27fd6f1c162L422-R469) [[5]](diffhunk://#diff-6528bc20d3aa7a292ad6698508df2ec69b2941bd0aa39c40a791a27fd6f1c162R537-R602)